### PR TITLE
FIX : README.md : Screen Shots not Visible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.gif filter=lfs diff=lfs merge=lfs -text

--- a/ScreenShots/Africa_SS_1.gif
+++ b/ScreenShots/Africa_SS_1.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06579a13baecb432dbac57492eb69eb01a970e0f43e0962fc9598683dada2007
-size 27705695

--- a/ScreenShots/Africa_SS_2.gif
+++ b/ScreenShots/Africa_SS_2.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:090ad43272d0516be98277e39bfcacba8e9535f5b2d314d8aa7f35701de8ff1a
-size 47142848

--- a/ScreenShots/Africa_SS_3.gif
+++ b/ScreenShots/Africa_SS_3.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:093135d08f14c0db2e6440bc9203e85f6967f09482541d419866a1ae266b9b9c
-size 144885230

--- a/ScreenShots/Africa_SS_4.gif
+++ b/ScreenShots/Africa_SS_4.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be3d061b32d77082a82943f6541a18bf4096fd4009de38485ef606f14e747a78
-size 6884063

--- a/ScreenShots/Africa_SS_5.gif
+++ b/ScreenShots/Africa_SS_5.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abc6531f0c3b3d3b3bab21b43432fe1beec8acf303ebefc00be381d317685363
-size 19092857


### PR DESCRIPTION
### **Description**
Screen Shots were visible in `README.md` for some time, but now it's not.

### **Root Cause**
All the `.gif`s were uploaded using [Git LFS](https://git-lfs.github.com/). The decision to use LFS was because of one `.gif` exceeding the 100 MB mark. But, it turns out, [Git LFS](https://git-lfs.github.com/) stores the files under a separate remote server, instead of uploading it back to GitHub. So any transaction in files (whether it's reading or writing) from the remote server can turn into monetary transaction as there are costs involved in maintaining a remote server.

### **Fix Implemented**
- Removed all the GIFs that were previously uploaded using [Git LFS](https://git-lfs.github.com/). Also removed the `.gitattribute` File as it is used in conjunction with using Git LFS.
- Re-Build the `Africa_SS_3.gif` with compressed size so that it doesn't exceed 100 MB.
- Packaged all the Screen Shots GIFs in a Commit.